### PR TITLE
Migrating to start_ipython completely functional shell instead of embedded

### DIFF
--- a/flask_shell_ipython.py
+++ b/flask_shell_ipython.py
@@ -17,8 +17,12 @@ def shell(ipython_args):
     without having to manually configuring the application.
     """
     import IPython
+    from IPython.terminal.ipapp import load_default_config
     from flask.globals import _app_ctx_stack
     app = _app_ctx_stack.top.app
+    ctx = {}
+    ctx.update(app.make_shell_context())
+
     banner = 'Python %s on %s\nIPython: %s\nApp: %s%s\nInstance: %s\n' % (
         sys.version,
         sys.platform,
@@ -27,10 +31,7 @@ def shell(ipython_args):
         app.debug and ' [debug]' or '',
         app.instance_path,
     )
+    config = app.config.get('IPYTHON_CONFIG') or load_default_config()
+    config.TerminalInteractiveShell.banner1 = banner
 
-    ctx = {}
-
-    ctx.update(app.make_shell_context())
-
-    IPython.start_ipython(argv=ipython_args, banner1=banner, user_ns=ctx,
-                          config=app.config.get('IPYTHON_CONFIG'))
+    IPython.start_ipython(argv=ipython_args, user_ns=ctx, config=config)

--- a/flask_shell_ipython.py
+++ b/flask_shell_ipython.py
@@ -18,6 +18,7 @@ def shell(ipython_args):
     """
     import IPython
     from IPython.terminal.ipapp import load_default_config
+    from traitlets.config.loader import Config
     from flask.globals import _app_ctx_stack
     app = _app_ctx_stack.top.app
     ctx = {}
@@ -31,7 +32,7 @@ def shell(ipython_args):
         app.debug and ' [debug]' or '',
         app.instance_path,
     )
-    config = app.config.get('IPYTHON_CONFIG') or load_default_config()
+    config = Config(app.config.get('IPYTHON_CONFIG')) or load_default_config()
     config.TerminalInteractiveShell.banner1 = banner
 
     IPython.start_ipython(argv=ipython_args, user_ns=ctx, config=config)

--- a/flask_shell_ipython.py
+++ b/flask_shell_ipython.py
@@ -4,9 +4,10 @@ import click
 from flask.cli import with_appcontext
 
 
-@click.command()
+@click.command(context_settings=dict(ignore_unknown_options=True))
+@click.argument('ipython_args', nargs=-1, type=click.UNPROCESSED)
 @with_appcontext
-def shell():
+def shell(ipython_args):
     """Runs a shell in the app context.
 
     Runs an interactive Python shell in the context of a given
@@ -31,5 +32,5 @@ def shell():
 
     ctx.update(app.make_shell_context())
 
-    IPython.start_ipython(argv=app.config.get('IPYTHON_ARGV', []),
-                          banner1=banner, user_ns=ctx, config=app.config.get('IPYTHON_CONFIG'))
+    IPython.start_ipython(argv=ipython_args, banner1=banner, user_ns=ctx,
+                          config=app.config.get('IPYTHON_CONFIG'))

--- a/flask_shell_ipython.py
+++ b/flask_shell_ipython.py
@@ -32,7 +32,10 @@ def shell(ipython_args):
         app.debug and ' [debug]' or '',
         app.instance_path,
     )
-    config = Config(app.config.get('IPYTHON_CONFIG')) or load_default_config()
+    if 'IPYTHON_CONFIG' in app.config:
+        config = Config(app.config['IPYTHON_CONFIG'])
+    else:
+        config = load_default_config()
     config.TerminalInteractiveShell.banner1 = banner
 
     IPython.start_ipython(argv=ipython_args, user_ns=ctx, config=config)

--- a/flask_shell_ipython.py
+++ b/flask_shell_ipython.py
@@ -1,8 +1,6 @@
-import os
 import sys
 
 import click
-
 from flask.cli import with_appcontext
 
 
@@ -31,13 +29,7 @@ def shell():
 
     ctx = {}
 
-    # Support the regular Python interpreter startup script if someone
-    # is using it.
-    startup = os.environ.get('PYTHONSTARTUP')
-    if startup and os.path.isfile(startup):
-        with open(startup, 'r') as f:
-            eval(compile(f.read(), startup, 'exec'), ctx)
-
     ctx.update(app.make_shell_context())
 
-    IPython.embed(banner1=banner, user_ns=ctx)
+    IPython.start_ipython(argv=app.config.get('IPYTHON_ARGV', []),
+                          banner1=banner, user_ns=ctx, config=app.config.get('IPYTHON_CONFIG'))


### PR DESCRIPTION
Like I understood there was reason to use InteactiveShellEmbed instead of full InteractiveShellApp interface, obviously because of some problems with app context? But as of Flask 0.12.1 and ipython 0.5.3 full shell seems to be running inside app context anyway. Have I missed something?

Embedded interface is not running InteractiveShellApp features (such as exec_lines, exec_file, exec custom code on starting ipython), so you can't easily configure it automatically after ipython is started.
, and you can't pass shell arguments there.

With this fix:
1. you can pass ipython arguments to flask shell
2. you can configure ipython from app.config['IPYTHON_CONFIG']
3. As it's running not in embedded mode, configuration options such as exec_lines, exec_file, etc. is not ignored from passed config.