### PR TITLE
Make banner more consistent with builtin flask shell

### DIFF
--- a/flask_shell_ipython.py
+++ b/flask_shell_ipython.py
@@ -30,12 +30,12 @@ def shell(ipython_args):
 
     config.TerminalInteractiveShell.banner1 = '''Python %s on %s
 IPython: %s
-App: %s%s
+App: %s [%s]
 Instance: %s''' % (sys.version,
                    sys.platform,
                    IPython.__version__,
                    app.import_name,
-                   app.debug and ' [debug]' or '',
+                   app.env,
                    app.instance_path)
 
     IPython.start_ipython(


### PR DESCRIPTION
I just tried out this library and noticed that it is only showing "debug" or not, while the built-in flask shell shows the environment you're in. The environment name is really helpful to see (i.e. as a sanity check to know if you're in a remote production shell or development), and it also seems nice to keep this consistent with the built-in flask shell command.