### PR TITLE
Replace app.env with app.debug beacase app.env has been removed at flask 2.3.0

### DIFF
--- a/flask_shell_ipython.py
+++ b/flask_shell_ipython.py
@@ -30,12 +30,13 @@ def shell(ipython_args):
 
     config.TerminalInteractiveShell.banner1 = '''Python %s on %s
 IPython: %s
-App: %s [%s]
+App: %s
+Debug: %s
 Instance: %s''' % (sys.version,
                    sys.platform,
                    IPython.__version__,
                    app.import_name,
-                   app.env,
+                   app.debug,
                    app.instance_path)
 
     IPython.start_ipython(


### PR DESCRIPTION
https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-0